### PR TITLE
Update gwtf file

### DIFF
--- a/bin/gwtf
+++ b/bin/gwtf
@@ -76,4 +76,4 @@ on_error do |exception|
   true
 end
 
-exit GLI.run(ARGV)
+exit run(ARGV)


### PR DESCRIPTION
GLI.run no longer works for GLI-2, you must just call `run(ARGV)'
